### PR TITLE
doc(README): added installation instructions using uv and pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,20 @@ You should see: `✓ Logged in to github.com as YOUR_USERNAME`
 
 ## Installing `gitfetch`
 
+### With `uv`
 
+```bash
+uv tool install git+https://github.com/Matars/gitfetch
+```
+
+### With `pipx`
+
+```bash
+pipx install git+https://github.com/Matars/gitfetch
+```
+
+### From the sources
+  
 1. Clone this repo
 2. `cd` into the repo
 3. Then type the below command


### PR DESCRIPTION
Just add basic install instructions using `uv` or `pipx`, avoiding the need to clone the repository manually.