### PR TITLE
Adding Homebrew formula and updating README for Homebrew installation

### DIFF
--- a/Formula/gitfetch.rb
+++ b/Formula/gitfetch.rb
@@ -1,0 +1,49 @@
+class Gitfetch < Formula
+  include Language::Python::Virtualenv
+
+  desc "A neofetch alternative for GitHub quick view"
+  homepage "https://github.com/Matars/gitfetch"
+  url "https://github.com/Matars/gitfetch/archive/refs/tags/v1.1.7.tar.gz"
+  sha256 "6ae1b2977f459a15352375f46cd56133eec4c37812b71448528a44f43b77f1f6"
+  license "GPL-2.0"
+
+  depends_on "python@3.14"
+
+  resource "certifi" do
+    url "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz"
+    sha256 "47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"
+  end
+
+  resource "charset-normalizer" do
+    url "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz"
+    sha256 "94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a"
+  end
+
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz"
+    sha256 "795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
+  end
+
+  resource "readchar" do
+    url "https://files.pythonhosted.org/packages/dd/f8/8657b8cbb4ebeabfbdf991ac40eca8a1d1bd012011bd44ad1ed10f5cb494/readchar-4.2.1.tar.gz"
+    sha256 "91ce3faf07688de14d800592951e5575e9c7a3213738ed01d394dcc949b79adb"
+  end
+
+  resource "requests" do
+    url "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz"
+    sha256 "dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
+  end
+
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz"
+    sha256 "3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match("gitfetch version", shell_output("#{bin}/gitfetch --version"))
+  end
+end

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A neofetch-style CLI tool for GitHub, GitLab, Gitea, Forgejo, Codeberg, and Sour
   </tr>
 </table>
 
-
 <img width="3441" height="1441" alt="2025-10-20-143110_hyprshot" src="https://github.com/user-attachments/assets/ee31ebe3-257f-4aff-994e-fffd47b48fa1" />
 
 ## Features
@@ -53,8 +52,8 @@ The setup process will provide helpful error messages and installation instructi
 ### macOS (Homebrew)
 
 ```bash
-brew tap matars/gitfetch
-brew install matars/gitfetch/gitfetch
+brew tap matars/gitfetch https://github.com/matars/gitfetch
+brew install gitfetch
 ```
 
 ### Arch Linux (AUR)


### PR DESCRIPTION
This change resolves #29. Homebrew assumes that there is a repo at `https://github.com/<user>/homebrew-<repo>` when simply running `brew tap <user>/<repo>`.

This can be fixed by adding the URL as a second argument. I have already made the changes to the README file.

I also added a formula for the installation, which should work, but it may not be the best practice. You can now install by simply running `brew install gitfetch` after tapping `matars/gitfetch`.