### PR TITLE
fix: correct import path in test_cache.py

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-from src.gitfetch.cache import CacheManager
+from gitfetch.cache import CacheManager
 
 
 class TestCacheManager:


### PR DESCRIPTION
## Problem

Running `pytest tests/` after `pip install -e .` fails with:

```
ModuleNotFoundError: No module named 'src'
```

This is because `test_cache.py` uses `from src.gitfetch.cache import CacheManager`, but after editable install, the package name is `gitfetch`, not `src.gitfetch`.

## Solution

Change the import from:
```python
from src.gitfetch.cache import CacheManager
```
to:
```python
from gitfetch.cache import CacheManager
```

## Testing

After this fix, all 4 tests in `test_cache.py` pass:

```
$ pytest tests/test_cache.py -v
tests/test_cache.py::TestCacheManager::test_cache_expiry PASSED
tests/test_cache.py::TestCacheManager::test_stale_cache_retrieval PASSED
tests/test_cache.py::TestCacheManager::test_cache_minutes_parameter PASSED
tests/test_cache.py::TestCacheManager::test_cache_timestamp_update PASSED

============================== 4 passed ==============================
```