### PR TITLE
build(nix): add `webcolors` to flake build instruction

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
             requests
             readchar
             setuptools
+            webcolors
           ];
 
           # Dependencies for testing


### PR DESCRIPTION
`webcolors` is introduced in #60, which the pr aims to support `nix flake` usage with.

[`pyproject.toml`](https://github.com/Matars/gitfetch/blob/43a3a552e0ce53f3f9b23e1946c1a1d5697ce66e/pyproject.toml#L29-L32) probably has to be updated for this, but that's outside the scope of this.